### PR TITLE
Use HTMLMediaElement.srcObject to load the selected file.

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,11 +193,8 @@
         console.log("Selected file to populate box:", selectedFile);
 
         if (mediaElement) {
-          const fileReader = new FileReader();
-          fileReader.onload = () => {
-            mediaElement.src = fileReader.result;
-          };
-          fileReader.readAsDataURL(selectedFile);
+          mediaElement.srcObject = selectedFile;
+          mediaElement.load();
         }
 
         document


### PR DESCRIPTION
It's not necessary to convert a `File` object into a "data://" URI in order to load that `File` using `HTMLMediaElement`. Because `File` is a subclass of `Blob`, it can be set directly on ``HTMLMediaElement.srcObject`.